### PR TITLE
Typo fix in READEME.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ There are two options available:
 ```swift
 let dict = ["1":2, "2":"two", "3": nil] as [String: Any?]
 let json = JSON(dict)
-let representation = json.rawString(options: [.castNilToNSNull: true])
+let representation = json.rawString([.castNilToNSNull: true])
 // representation is "{\"1\":2,\"2\":\"two\",\"3\":null}", which represents {"1":2,"2":"two","3":null}
 ```
 


### PR DESCRIPTION
rawString() no longer requires the parameter name explicitly

The PR should summarize what was changed and why. Here are some questions to
help you if you're not sure:

 - What behavior was changed?
 - What code was refactored / updated to support this change?
 - What issues are related to this PR? Or why was this change introduced?

Checklist - While not every PR needs it, new features should consider this list:

 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?